### PR TITLE
Fixed support for C++11 threads

### DIFF
--- a/image/build.sh
+++ b/image/build.sh
@@ -346,7 +346,19 @@ function install_libstdcxx()
 
 		export CFLAGS="$STATICLIB_CFLAGS"
 		export CXXFLAGS="$STATICLIB_CXXFLAGS"
-		../gcc-$GCC_LIBSTDCXX_VERSION/libstdc++-v3/configure \
+
+		run mkdir libgcc
+		echo "+ Entering /gcc-build/libgcc"
+		cd libgcc
+		run chmod +x ../../gcc-$GCC_LIBSTDCXX_VERSION/libgcc/configure
+		../../gcc-$GCC_LIBSTDCXX_VERSION/libgcc/configure \
+			--prefix=$PREFIX --disable-multilib \
+			--disable-shared
+
+		run mkdir ../libstdc++-v3
+		echo "+ Entering /gcc-build/libstdc++-v3"
+		cd ../libstdc++-v3
+		../../gcc-$GCC_LIBSTDCXX_VERSION/libstdc++-v3/configure \
 			--prefix=$PREFIX --disable-multilib \
 			--disable-libstdcxx-visibility --disable-shared
 		run make -j$MAKE_CONCURRENCY


### PR DESCRIPTION
libstdc++-v3 includes a configure test that looks for the internal
gthread library. This configure test decides in part whether C++11
thread support will be built.

As part of this test it tries to include "gtrd.h", which in turn
includes "gtrd-default.h", which is not found by the test since it
only seems to look for it in the configured build tree of libgcc.

So we simply run configure for libgcc so that it generates the needed
headers before building libstdc++.