### PR TITLE
Make Python build with the sqlite3 module

### DIFF
--- a/image/build.sh
+++ b/image/build.sh
@@ -292,39 +292,6 @@ if ! eval_bool "$SKIP_CMAKE"; then
 fi
 
 
-### Python
-
-if ! eval_bool "$SKIP_PYTHON"; then
-	header "Installing Python $PYTHON_VERSION"
-	download_and_extract Python-$PYTHON_VERSION.tgz \
-		Python-$PYTHON_VERSION \
-		https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tgz
-
-	(
-		activate_holy_build_box_deps_installation_environment
-		run ./configure --prefix=/hbb
-		run make -j$MAKE_CONCURRENCY install
-		run strip --strip-all /hbb/bin/python
-		run strip --strip-debug /hbb/lib/python*/lib-dynload/*.so
-	)
-	if [[ "$?" != 0 ]]; then false; fi
-
-	run hash -r
-
-	echo "Leaving source directory"
-	popd >/dev/null
-	run rm -rf Python-$PYTHON_VERSION
-
-	# Install setuptools and pip
-	echo "Installing setuptools and pip..."
-	run curl -OL --fail https://bootstrap.pypa.io/ez_setup.py
-	run python ez_setup.py
-	run rm -f ez_setup.py
-	run easy_install pip
-	run rm -f /setuptools*.zip
-fi
-
-
 ## libstdc++
 
 function install_libstdcxx()
@@ -539,6 +506,42 @@ if ! eval_bool "$SKIP_SQLITE"; then
 	for VARIANT in $VARIANTS; do
 		run rm -f /hbb_$VARIANT/bin/sqlite3
 	done
+fi
+
+
+### Python
+
+if ! eval_bool "$SKIP_PYTHON"; then
+	header "Installing Python $PYTHON_VERSION"
+	download_and_extract Python-$PYTHON_VERSION.tgz \
+		Python-$PYTHON_VERSION \
+		https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tgz
+
+	(
+		activate_holy_build_box_deps_installation_environment
+		export CPPFLAGS="$CPPFLAGS -I/hbb_shlib/include"
+		export LDFLAGS="$LDFLAGS -L/hbb_shlib/lib"
+
+		run ./configure --prefix=/hbb
+		run make -j$MAKE_CONCURRENCY install
+		run strip --strip-all /hbb/bin/python
+		run strip --strip-debug /hbb/lib/python*/lib-dynload/*.so
+	)
+	if [[ "$?" != 0 ]]; then false; fi
+
+	run hash -r
+
+	echo "Leaving source directory"
+	popd >/dev/null
+	run rm -rf Python-$PYTHON_VERSION
+
+	# Install setuptools and pip
+	echo "Installing setuptools and pip..."
+	run curl -OL --fail https://bootstrap.pypa.io/ez_setup.py
+	run python ez_setup.py
+	run rm -f ez_setup.py
+	run easy_install pip
+	run rm -f /setuptools*.zip
 fi
 
 


### PR DESCRIPTION
In order to do this we move Python to build after SQlite3 and
add the hbb_shlib variant to the include and library search paths
of Python. This allows Python to find the SQlite3 library that we
built for linking with shared library, which is what Python needs
in order to build the SQlite3 module.

This in general allows any Python module that will be built in Holy Build Box to be linked against libraries in the shlib variant.