### PR TITLE
Update to devtoolset-8

### DIFF
--- a/.github/workflows/dockerimage-ci.yml
+++ b/.github/workflows/dockerimage-ci.yml
@@ -2,6 +2,9 @@ name: Docker Image CI
 
 on:
   create:
+  pull_request:
+    branches:
+      - master
   push:
     tags-ignore: 
       - '**'
@@ -10,10 +13,22 @@ on:
       - fork/master
 
 jobs:
+  build_pr:
+    name: "Build PR Docker image"
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [32, 64]
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile-${{ matrix.arch }}
+    
 
   build_edge:
     name: "Build edge Docker image"
-    if: github.event_name != 'create'
+    if: github.event_name != 'create' && github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -29,7 +44,7 @@ jobs:
 
   build_release:
     name: "Build release Docker image"
-    if: github.event_name == 'create' && github.event.ref_type == 'tag'
+    if: github.event_name == 'create' && github.event.ref_type == 'tag' && github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/image/activate_func.sh
+++ b/image/activate_func.sh
@@ -1,5 +1,5 @@
 function activate_holy_build_box_deps_installation_environment() {
-	source /opt/rh/devtoolset-7/enable
+	source /opt/rh/devtoolset-8/enable
 	export PATH=/hbb/bin:$PATH
 	export C_INCLUDE_PATH=/hbb/include
 	export CPLUS_INCLUDE_PATH=/hbb/include
@@ -21,7 +21,7 @@ function activate_holy_build_box() {
 	local EXTRA_SHLIB_CFLAGS="$5"
 	local EXTRA_SHLIB_LDFLAGS="$6"
 
-	source /opt/rh/devtoolset-7/enable
+	source /opt/rh/devtoolset-8/enable
 
 	export PATH=$PREFIX/bin:/hbb/bin:$PATH
 	export C_INCLUDE_PATH=$PREFIX/include

--- a/image/activate_func.sh
+++ b/image/activate_func.sh
@@ -1,5 +1,10 @@
 function activate_holy_build_box_deps_installation_environment() {
-	source /opt/rh/devtoolset-8/enable
+	if [ `uname -m` != x86_64 ]; then
+		DEVTOOLSET_VER=7
+	else
+		DEVTOOLSET_VER=8
+	fi
+	source /opt/rh/devtoolset-${DEVTOOLSET_VER}/enable
 	export PATH=/hbb/bin:$PATH
 	export C_INCLUDE_PATH=/hbb/include
 	export CPLUS_INCLUDE_PATH=/hbb/include
@@ -21,7 +26,12 @@ function activate_holy_build_box() {
 	local EXTRA_SHLIB_CFLAGS="$5"
 	local EXTRA_SHLIB_LDFLAGS="$6"
 
-	source /opt/rh/devtoolset-8/enable
+	if [ `uname -m` != x86_64 ]; then
+		DEVTOOLSET_VER=7
+	else
+		DEVTOOLSET_VER=8
+	fi
+	source /opt/rh/devtoolset-${DEVTOOLSET_VER}/enable
 
 	export PATH=$PREFIX/bin:/hbb/bin:$PATH
 	export C_INCLUDE_PATH=$PREFIX/include

--- a/image/build.sh
+++ b/image/build.sh
@@ -85,13 +85,15 @@ run yum update -y
 run yum install -y curl epel-release tar
 
 header "Installing compiler toolchain"
-#if [ `uname -m` != x86_64 ]; then
-#curl -s https://packagecloud.io/install/repositories/phusion/centos-6-scl-i386/script.rpm.sh | bash
-#sed -i 's|$arch|i686|; s|\$basearch|i386|g' $CHROOT/etc/yum.repos.d/phusion*.repo
-#else
+if [ `uname -m` != x86_64 ]; then
+curl -s https://packagecloud.io/install/repositories/phusion/centos-6-scl-i386/script.rpm.sh | bash
+sed -i 's|$arch|i686|; s|\$basearch|i386|g' $CHROOT/etc/yum.repos.d/phusion*.repo
+DEVTOOLSET_VER=7
+else
 run yum install -y centos-release-scl
-#fi
-run yum install -y devtoolset-8 file patch bzip2 zlib-devel gettext
+DEVTOOLSET_VER=8
+fi
+run yum install -y devtoolset-${DEVTOOLSET_VER} file patch bzip2 zlib-devel gettext
 
 ### OpenSSL (system version, so that we can download from HTTPS servers with SNI)
 

--- a/image/build.sh
+++ b/image/build.sh
@@ -89,6 +89,8 @@ if [ `uname -m` != x86_64 ]; then
 curl -s https://packagecloud.io/install/repositories/phusion/centos-6-scl-i386/script.rpm.sh | bash
 sed -i 's|$arch|i686|; s|\$basearch|i386|g' $CHROOT/etc/yum.repos.d/phusion*.repo
 DEVTOOLSET_VER=7
+# a 32-bit version of devtoolset-8 would need to get compiled
+GCC_LIBSTDCXX_VERSION=7.3.0
 else
 run yum install -y centos-release-scl
 DEVTOOLSET_VER=8

--- a/image/build.sh
+++ b/image/build.sh
@@ -10,7 +10,7 @@ CCACHE_VERSION=3.5
 CMAKE_VERSION=3.16.4
 CMAKE_MAJOR_VERSION=3.16
 PYTHON_VERSION=2.7.15
-GCC_LIBSTDCXX_VERSION=7.3.0
+GCC_LIBSTDCXX_VERSION=8.3.0
 ZLIB_VERSION=1.2.11
 OPENSSL_VERSION=1.0.2q
 CURL_VERSION=7.63.0
@@ -91,7 +91,7 @@ sed -i 's|$arch|i686|; s|\$basearch|i386|g' $CHROOT/etc/yum.repos.d/phusion*.rep
 else
 run yum install -y centos-release-scl
 fi
-run yum install -y devtoolset-7 file patch bzip2 zlib-devel gettext
+run yum install -y devtoolset-8 file patch bzip2 zlib-devel gettext
 
 ### OpenSSL (system version, so that we can download from HTTPS servers with SNI)
 

--- a/image/build.sh
+++ b/image/build.sh
@@ -85,12 +85,12 @@ run yum update -y
 run yum install -y curl epel-release tar
 
 header "Installing compiler toolchain"
-if [ `uname -m` != x86_64 ]; then
-curl -s https://packagecloud.io/install/repositories/phusion/centos-6-scl-i386/script.rpm.sh | bash
-sed -i 's|$arch|i686|; s|\$basearch|i386|g' $CHROOT/etc/yum.repos.d/phusion*.repo
-else
+#if [ `uname -m` != x86_64 ]; then
+#curl -s https://packagecloud.io/install/repositories/phusion/centos-6-scl-i386/script.rpm.sh | bash
+#sed -i 's|$arch|i686|; s|\$basearch|i386|g' $CHROOT/etc/yum.repos.d/phusion*.repo
+#else
 run yum install -y centos-release-scl
-fi
+#fi
 run yum install -y devtoolset-8 file patch bzip2 zlib-devel gettext
 
 ### OpenSSL (system version, so that we can download from HTTPS servers with SNI)


### PR DESCRIPTION
Updates the 64-bit Docker image to devtoolset-8; some compiler bugs in gcc 7.3.0 are fixed in the newer devtoolset. The 32-bit image remains on devtoolset-7 because there is no easily available package repository with devtoolset-8 in it.