### PR TITLE
Use vault.centos.org, as centos6 is EOL

### DIFF
--- a/image/build.sh
+++ b/image/build.sh
@@ -72,14 +72,9 @@ for VARIANT in $VARIANTS; do
 done
 
 header "Updating system"
-if [ $(date --date '2020-11-30T00:00:00' +'%s') -lt $(date +'%s') ]; then
-run sed -i.bak -re 's/^(mirrorlist)/#\1/g' -e 's/^#(baseurl)/\1/g' -e 's/mirror(\.centos)/vault\1/g' -e 's|centos/\$releasever/([^/]+)/([^/]+)|'$CENTOS_VERSION'/\1/\2|g' /etc/yum.repos.d/CentOS-Base.repo
-rm /etc/yum.repos.d/CentOS-Base.repo.bak
-if [[ -f /etc/yum.repos.d/libselinux.repo ]]; then
-	run sed -i.bak -re 's/^(mirrorlist)/#\1/g' -e 's/^#(baseurl)/\1/g' -e 's/mirror(\.centos)/vault\1/g' -e 's|centos/\$releasever/([^/]+)/([^/]+)|'$CENTOS_VERSION'/\1/\2|g' /etc/yum.repos.d/libselinux.repo
-	rm /etc/yum.repos.d/libselinux.repo.bak
-fi
-fi
+# Fix base mirrors to use vault.centos.org
+run sed -i 's|^[# ]*baseurl=http://[^.]\+\.centos\.org|baseurl=http://vault.centos.org|g; s|^ *mirrorlist=http://mirrorlist\.centos\.org.*$||g' /etc/yum.repos.d/*.repo
+
 touch /var/lib/rpm/*
 run yum update -y
 run yum install -y curl epel-release tar
@@ -93,6 +88,8 @@ DEVTOOLSET_VER=7
 GCC_LIBSTDCXX_VERSION=7.3.0
 else
 run yum install -y centos-release-scl
+# Fix mirrors added by centos-release-scl to use vault.centos.org
+run sed -i 's|^[# ]*baseurl=http://[^.]\+\.centos\.org|baseurl=http://vault.centos.org|g; s|^ *mirrorlist=http://mirrorlist\.centos\.org.*$||g' /etc/yum.repos.d/*.repo
 DEVTOOLSET_VER=8
 fi
 run yum install -y devtoolset-${DEVTOOLSET_VER} file patch bzip2 zlib-devel gettext


### PR DESCRIPTION
This should address #23. I tested building `Dockerfile-32` and `Dockerfile-64`, and both completed successfully 

This change disables all uses of `mirrorlist.centos.org`. It also uncomments any `baseurl` line that references `centos.org`, and remaps them to `vault.centos.org`. I run the sed script to do this once before the first `yum update`, and then one more time on x86_64 after `centos-release-scl` is installed, because that package adds more repositories that need to be fixed.

Based on the fact that this works with the 32 bit build, which uses a centos6 base image that already uses `vault.centos.org` for all the core repositories, I'm confident this is forward compatible if the 64 bit centos6 base image is updated to use `vault.centos.org` by default

I'm not terribly familiar with this project, but was pulled in by a friend using it. Let me know if there's anything you need me to change.