### PR TITLE
ci: add a daily build

### DIFF
--- a/.github/workflows/dockerimage-ci.yml
+++ b/.github/workflows/dockerimage-ci.yml
@@ -30,7 +30,7 @@ jobs:
   # Catch changes to external dependencies (like CentOS package repository)
   build_daily:
     name: "Build Daily Docker image"
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/dockerimage-ci.yml
+++ b/.github/workflows/dockerimage-ci.yml
@@ -2,6 +2,8 @@ name: Docker Image CI
 
 on:
   create:
+  schedule:
+    - cron: '15 05 * * *' # Late night for the Americas, early morning for Europe
   pull_request:
     branches:
       - master
@@ -24,11 +26,23 @@ jobs:
     - uses: actions/checkout@v1
     - name: Build the Docker image
       run: docker build . --file Dockerfile-${{ matrix.arch }}
-    
+  
+  # Catch changes to external dependencies (like CentOS package repository)
+  build_daily:
+    name: "Build Daily Docker image"
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [32, 64]
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile-${{ matrix.arch }}
 
   build_edge:
     name: "Build edge Docker image"
-    if: github.event_name != 'create' && github.event_name != 'pull_request'
+    if: github.event_name != 'create' && github.event_name != 'pull_request' && github.event_name != 'schedule'
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Adds a daily build to catch changes to external Docker image build dependencies, like the CentOS package repository.