### PR TITLE
Fix YUM URLs

### DIFF
--- a/image/CentOS-Debuginfo.repo
+++ b/image/CentOS-Debuginfo.repo
@@ -1,0 +1,6 @@
+[base-debuginfo]
+name=CentOS-6 - Debuginfo
+baseurl=http://debuginfo.centos.org/6/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-Debug-6
+enabled=0

--- a/image/CentOS-Vault-SCLo.repo
+++ b/image/CentOS-Vault-SCLo.repo
@@ -1,0 +1,20 @@
+[CentOS-sclo]
+name=CentOS - SCLo sclo
+baseurl=https://vault.centos.org/6.10/sclo/$basearch/sclo/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
+enabled=1
+
+[CentOS-sclo-rh]
+name=CentOS - SCLo sclo-rh
+baseurl=https://vault.centos.org/6.10/sclo/$basearch/rh/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
+enabled=1
+
+[CentOS-sclo-debuginfo]
+name=CentOS - SCLo sclo Debuginfo
+baseurl=http://debuginfo.centos.org/centos/6/sclo/$basearch/
+gpgcheck=1
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo

--- a/image/CentOS-Vault.repo
+++ b/image/CentOS-Vault.repo
@@ -1,0 +1,62 @@
+# CentOS-Vault.repo
+#
+# CentOS Vault holds packages from previous releases within the same CentOS Version
+# these are packages obsoleted by the current release and should usually not 
+# be used in production
+#-----------------
+
+[CentOS-base]
+name=CentOS - Base
+baseurl=https://vault.centos.org/6.10/os/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+enabled=1
+
+[CentOS-updates]
+name=CentOS - Updates
+baseurl=https://vault.centos.org/6.10/updates/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+enabled=1
+
+#[CentOS-addons]
+#name=CentOS - Addons
+#baseurl=https://vault.centos.org/6.10/addons/$basearch/
+#gpgcheck=1
+#gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+#enabled=1
+
+[CentOS-extras]
+name=CentOS - Extras
+baseurl=https://vault.centos.org/6.10/extras/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+enabled=1
+
+[CentOS-contrib]
+name=CentOS - Contrib
+baseurl=https://vault.centos.org/6.10/contrib/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+enabled=1
+
+[CentOS-centosplus]
+name=CentOS - CentOSPlus
+baseurl=https://vault.centos.org/6.10/centosplus/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+enabled=1
+
+[CentOS-fasttrack]
+name=CentOS - FastTrack
+baseurl=https://vault.centos.org/6.10/fasttrack/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+enabled=1
+
+[CentOS-fasttrack]
+name=CentOS - FastTrack
+baseurl=https://vault.centos.org/6.10/fasttrack/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+enabled=1

--- a/image/build.sh
+++ b/image/build.sh
@@ -72,8 +72,10 @@ for VARIANT in $VARIANTS; do
 done
 
 header "Updating system"
-# Fix base mirrors to use vault.centos.org
-run sed -i 's|^[# ]*baseurl=http://[^.]\+\.centos\.org|baseurl=http://vault.centos.org|g; s|^ *mirrorlist=http://mirrorlist\.centos\.org.*$||g' /etc/yum.repos.d/*.repo
+run rm -f /etc/yum.repos.d/CentOS-Base.repo
+run rm -f /etc/yum.repos.d/CentOS-fasttrack.repo
+run cp /hbb_build/CentOS-Vault.repo /etc/yum.repos.d/
+run cp /hbb_build/CentOS-Debuginfo.repo /etc/yum.repos.d/
 
 touch /var/lib/rpm/*
 run yum update -y
@@ -88,8 +90,9 @@ DEVTOOLSET_VER=7
 GCC_LIBSTDCXX_VERSION=7.3.0
 else
 run yum install -y centos-release-scl
-# Fix mirrors added by centos-release-scl to use vault.centos.org
-run sed -i 's|^[# ]*baseurl=http://[^.]\+\.centos\.org|baseurl=http://vault.centos.org|g; s|^ *mirrorlist=http://mirrorlist\.centos\.org.*$||g' /etc/yum.repos.d/*.repo
+run rm -f /etc/yum.repos.d/CentOS-SCLo-scl.repo
+run rm -f /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
+run cp /hbb_build/CentOS-Vault-SCLo.repo /etc/yum.repos.d/
 DEVTOOLSET_VER=8
 fi
 run yum install -y devtoolset-${DEVTOOLSET_VER} file patch bzip2 zlib-devel gettext


### PR DESCRIPTION
YUM is broken because CentOS-Base.repo, CentOS-SCLo-scl.repo, CentOS-SLCo-slc-rh.repo and CentOS-fasttrack.repo all reference mirrorlist.centos.org, which no longer works.

We remove these files and replace all entries with equivalents that point to vault.centos.org. Unlike the CentOS-Vault.repo provided by the upstream Docker image, which unnecessarily references multiple CentOS versions and also doesn't reference CentOS 6.10, we only reference CentOS 6.10.

Additionally, we use https URLs. So this pull request obsoletes #26.