### PR TITLE
Increase CI and testing speed by disabling optimizations where appropriate

### DIFF
--- a/.github/workflows/dockerimage-ci.yml
+++ b/.github/workflows/dockerimage-ci.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build the Docker image
-      run: docker build . --file Dockerfile-${{ matrix.arch }}
+      run: docker build . --file Dockerfile-${{ matrix.arch }} --build-arg DISABLE_OPTIMIZATIONS=1
 
   build_edge:
     name: "Build edge Docker image"
@@ -53,7 +53,7 @@ jobs:
     - name: Login to GitHub Docker Package Registry
       run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u github-actions --password-stdin
     - name: Build the Docker image
-      run: docker build . --file Dockerfile-${{ matrix.arch }} --tag docker.pkg.github.com/phusion/holy-build-box/hbb-${{ matrix.arch }}:edge
+      run: docker build . --file Dockerfile-${{ matrix.arch }} --build-arg DISABLE_OPTIMIZATIONS=1 --tag docker.pkg.github.com/phusion/holy-build-box/hbb-${{ matrix.arch }}:edge
     - name: Push the Docker image
       run: docker push docker.pkg.github.com/phusion/holy-build-box/hbb-${{ matrix.arch }}:edge
 

--- a/Dockerfile-32
+++ b/Dockerfile-32
@@ -1,3 +1,4 @@
 FROM phusion/centos-6-32:latest
 ADD image /hbb_build
+ARG DISABLE_OPTIMIZATIONS=0
 RUN linux32 bash /hbb_build/build.sh

--- a/Dockerfile-64
+++ b/Dockerfile-64
@@ -1,3 +1,4 @@
 FROM centos:6
 ADD image /hbb_build
+ARG DISABLE_OPTIMIZATIONS=0
 RUN bash /hbb_build/build.sh

--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,11 @@ all: 32 64
 
 test:
 	echo "*** You should run: SKIP_FINALIZE=1 linux32 bash /hbb_build/build.sh"
-	docker run -t -i --rm -v `pwd`/image:/hbb_build:ro phusion/centos-6-32:latest bash
+	docker run -t -i --rm -e DISABLE_OPTIMIZATIONS=1 -v `pwd`/image:/hbb_build:ro phusion/centos-6-32:latest bash
 
 test64:
 	echo "*** You should run: SKIP_FINALIZE=1 bash /hbb_build/build.sh"
-	docker run -t -i --rm -v `pwd`/image:/hbb_build:ro centos:6 bash
+	docker run -t -i --rm -e DISABLE_OPTIMIZATIONS=1 -v `pwd`/image:/hbb_build:ro centos:6 bash
 
 tags:
 	docker tag phusion/holy-build-box-32:$(VERSION) phusion/holy-build-box-32:$(MAJOR_VERSION)

--- a/image/functions.sh
+++ b/image/functions.sh
@@ -47,3 +47,25 @@ function eval_bool()
 	local VAL="$1"
 	[[ "$VAL" = 1 || "$VAL" = true || "$VAL" = yes || "$VAL" = y ]]
 }
+
+function set_default_cflags()
+{
+	# shellcheck disable=SC2030
+	CFLAGS=$(adjust_optimization_level "-O2")
+	CXXFLAGS="$CFLAGS"
+	export CFLAGS
+	export CXXFLAGS
+}
+
+# Given a string containing compiler flags, adjusts optimization level flags according
+# to global settings.
+function adjust_optimization_level()
+{
+	local VAL="$1"
+	if eval_bool "$DISABLE_OPTIMIZATIONS"; then
+		# shellcheck disable=SC2001
+		sed 's|-O[0-9]*||g' <<<"$VAL"
+	else
+		echo "$VAL"
+	fi
+}

--- a/image/variants/exe_gc_hardened.sh
+++ b/image/variants/exe_gc_hardened.sh
@@ -2,6 +2,8 @@
 
 # shellcheck source=image/activate_func.sh
 source /hbb/activate_func.sh
+# Fortify Source requires optimizations, though no higher than -O2.
+export DISABLE_OPTIMIZATIONS=false
 export O3_ALLOWED=false
 activate_holy_build_box /hbb_exe_gc_hardened \
 	"-ffunction-sections -fdata-sections -fstack-protector -D_FORTIFY_SOURCE=2 -fPIE" \


### PR DESCRIPTION
Only build with optimizations during a release build, or when building the exe_gc_hardened variant. The latter is always built with optimizations because Fortify Source requires so.

This makes the CI 5-10 minutes faster (from ~36 minutes down to ~26-31m).