### PR TITLE
Website: drop x86 support, upgrade GCC and C++ version

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@
             <div class="row">
                 <div class="col-md-10 col-md-offset-1  col-lg-8 col-lg-offset-2  text-center">
                     <h2 class="section-heading">Holy Build Box to the rescue</h2>
-                    <p class="lead">Holy Build Box is a system for building "portable" binaries for Linux: binaries that work on pretty much any Linux distribution. This works by providing an easy-to-use, isolated, tightly-controlled compilation environment that is designed for producing portable binaries. Holy Build Box can produce x86 and x86-64 binaries.</p>
+                    <p class="lead">Holy Build Box is a system for building "portable" binaries for Linux: binaries that work on pretty much any Linux distribution. This works by providing an easy-to-use, isolated, tightly-controlled compilation environment that is designed for producing portable binaries. Holy Build Box can produce x86_64 binaries.</p>
                     <p><a href="https://github.com/phusion/holy-build-box#problem-introduction">Problem introduction</a>
                     | <a href="https://github.com/phusion/holy-build-box#faq">FAQ</a>
                     | <a href="https://github.com/phusion/holy-build-box#getting-started">Walkthrough</a></p>
@@ -209,8 +209,8 @@
                     <p>Holy Build Box runs on your Linux workstation. No need for a fleet of virtual machines for the purpose of producing distribution-version-specific packages.</p>
                 </div>
                 <div class="col-md-4">
-                    <h3>C++11</h3>
-                    <p>Holy Build Box ships GCC 4.8. This allows you to develop in C++11 even if you have to target distributions with older GCC versions.</p>
+                    <h3>C++14</h3>
+                    <p>Holy Build Box ships GCC 9.3. This allows you to develop in C++14 even if you have to target distributions with older GCC versions.</p>
                 </div>
             </div>
 


### PR DESCRIPTION
Don't merge this until version 3.0.0 (#37) has been released.