### PR TITLE
Add support for aarch64  

### DIFF
--- a/Dockerfile-aarch64
+++ b/Dockerfile-aarch64
@@ -1,0 +1,4 @@
+FROM centos:7
+ADD image /hbb_build
+ARG DISABLE_OPTIMIZATIONS=0
+RUN bash /hbb_build/build.sh

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ IMAGE = ghcr.io/$(OWNER)/holy-build-box-$(ARCH)
 build:
 	docker build --rm -t $(IMAGE):$(VERSION) -f Dockerfile-$(ARCH) --pull --build-arg DISABLE_OPTIMIZATIONS=$(DISABLE_OPTIMIZATIONS) .
 
+build-aarch64:
+	docker buildx build --rm -t ghcr.io/$(OWNER)/holy-build-box-aarch64:$(VERSION) -f Dockerfile-aarch64 --pull --platform=linux/arm64 --build-arg DISABLE_OPTIMIZATIONS=$(DISABLE_OPTIMIZATIONS) .
+
 test:
 	@echo "*** You should run: SKIP_FINALIZE=1 bash /hbb_build/build.sh"
 	docker run -t -i --rm -e DISABLE_OPTIMIZATIONS=1 -v $$(pwd)/image:/hbb_build:ro centos:7 bash

--- a/image/build.sh
+++ b/image/build.sh
@@ -68,7 +68,7 @@ if ! eval_bool "$SKIP_INITIALIZE"; then
 		epel-release centos-release-scl
 	run yum install -y python2-pip "devtoolset-$DEVTOOLSET_VERSION"
 
-	echo "*link_gomp: %{static|static-libgcc|static-libstdc++|static-libgfortran: libgomp.a%s; : -lgomp } %{static: -ldl }" > /opt/rh/devtoolset-9/root/usr/lib/gcc/x86_64-redhat-linux/9/libgomp.spec
+	echo "*link_gomp: %{static|static-libgcc|static-libstdc++|static-libgfortran: libgomp.a%s; : -lgomp } %{static: -ldl }" > /opt/rh/devtoolset-9/root/usr/lib/gcc/$(arch)-redhat-linux/9/libgomp.spec
 fi
 
 


### PR DESCRIPTION
Hey all,

I'm trying to add support of aarch64 in phusion/passenger-$tool, that based on phusion/baseimage (that is already support aarch64 images).

I discovered that this repo is point 0 in this interesting journey, because it used in https://github.com/phusion/passenger_binary_build_automation

This pr is pretty straight forward:
1. Because centos:7 have already support different type of archs (aarch64 included) https://hub.docker.com/layers/centos/library/centos/7/images/sha256-dead07b4d8ed7e29e98de0f4504d87e8880d4347859d839686a31da35a3b532f?context=explore
2. only one line in code is linked to `x86_64`, and can be easily unified with `arch` command


But there are some issues here:
1. adding support of releasing multiarch builds of docker: using buildx (new modern way) or using multiple docker images (old way like you have before with 32-bit version)


Also, I would be very happy, if you provide me some help with my next steps for adding support to use phusion/passenger-$tool on arm machines without any pain.

Thanks in advance.
