### PR TITLE
use arm64 GitHub Actions runners for arm64 docker image builds

### DIFF
--- a/.github/workflows/dockerimage-ci.yml
+++ b/.github/workflows/dockerimage-ci.yml
@@ -34,12 +34,17 @@ jobs:
   build_pr:
     name: "Test Build Docker images"
     if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || ( github.event_name != 'create' && github.event_name != 'pull_request' && github.event_name != 'schedule' )
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         arch:
           - 'amd64'
           - 'arm64'
+        include:
+          - arch: 'amd64'
+            os: ubuntu-latest
+          - arch: 'arm64'
+            os: ubuntu-24.04-arm
     env:
       OWNER: '${{ github.repository_owner }}'
     steps:
@@ -68,12 +73,17 @@ jobs:
   build_release:
     name: "Build release Docker images"
     if: github.event_name == 'create' && github.event.ref_type == 'tag'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         arch:
           - 'amd64'
           - 'arm64'
+        include:
+          - arch: 'amd64'
+            os: ubuntu-latest
+          - arch: 'arm64'
+            os: ubuntu-24.04-arm
     env:
       TAG: ${{ github.event.ref }}
       OWNER: '${{ github.repository_owner }}'


### PR DESCRIPTION
GitHub just announced the availability of Linux arm64 runners for public repositories: https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

This change updates the CI workflow to use the arm64 runners for building the arm64 Docker images, resulting in build times on par with (or a bit faster than) the amd64 Linux build. As of when I created this PR, the "Before" run is still going and I'm estimating will take 4+ hours to finish.

Architecture | Before            | After
-------------|--------------|-------
amd64          | 17m 42s         | 17m 8s
arm64           | 1h 56m 53s+ | 16m 14s

Before Run: https://github.com/nightlark/holy-build-box/actions/runs/12818429695/job/35743918705
After Run: https://github.com/nightlark/holy-build-box/actions/runs/12819551315/job/35747418552